### PR TITLE
updated ParamEffect getter

### DIFF
--- a/rhalphalib/sample.py
+++ b/rhalphalib/sample.py
@@ -208,7 +208,7 @@ class TemplateSample(Sample):
         if up:
             return self._paramEffectsUp[param]
         else:
-            if self._paramEffectsDown[param] is None:
+            if param not in self._paramEffectsDown or self._paramEffectsDown[param] is None:
                 # TODO the symmeterized value depends on if param prior is 'shapeN' or 'shape'
                 return 1. / self._paramEffectsUp[param]
             return self._paramEffectsDown[param]


### PR DESCRIPTION
Hi,

with this getParamEffect will check if the param-key exists in the paramEffectsDown dict, before checking if its value is None.

In some cases the key didn't exist. I think this happened, because the effect of some variations were too small (thus setParamEffect returned "early" in [this line](https://github.com/nsmith-/rhalphalib/blob/4d69c382430086946b1399b3fe53b5dee38340f4/rhalphalib/sample.py#L191))

I'm not sure if this is a good way to fix this, but right now it works for me.

Best
Steffen