### PR TITLE
Allow multiple-parameter normalization effects in TemplateSample

### DIFF
--- a/rhalphalib/model.py
+++ b/rhalphalib/model.py
@@ -334,7 +334,9 @@ class Channel(object):
 
             for param in otherParams:
                 fout.write("{0} extArg {1}.root:{1}\n".format(param.name, workspaceName))
-                # identify any normalization modifiers
+
+            # identify any normalization modifiers
+            for param in otherParams:
                 for sample in signalSamples + bkgSamples:
                     effect = sample.combineParamEffect(param)
                     if effect != '-':


### PR DESCRIPTION
One parameter is used as the reference for the effect, and the others
come along for the ride.  They are put in the combine card ahead of the
rateParam declaration so all formulas should work.
All parameters the effect depends on are required to be independent still,
to reduce the rendering headache.