### PR TITLE
Small change to get rid of ROOT-Warning

### DIFF
--- a/rhalphalib/util.py
+++ b/rhalphalib/util.py
@@ -42,8 +42,8 @@ def _to_numpy(hinput, read_sumw2=False):
 
 def _to_TH1(sumw, binning, name):
     import ROOT
+    ROOT.TH1.AddDirectory(False)
     h = ROOT.TH1D(name, "template;%s;Counts" % name, binning.size - 1, binning)
-    h.SetDirectory(0)
     if isinstance(sumw, tuple):
         for i, (w, w2) in enumerate(zip(sumw[0], sumw[1])):
             h.SetBinContent(i + 1, w)

--- a/rhalphalib/util.py
+++ b/rhalphalib/util.py
@@ -42,7 +42,6 @@ def _to_numpy(hinput, read_sumw2=False):
 
 def _to_TH1(sumw, binning, name):
     import ROOT
-    ROOT.TH1.AddDirectory(False)
     h = ROOT.TH1D(name, "template;%s;Counts" % name, binning.size - 1, binning)
     if isinstance(sumw, tuple):
         for i, (w, w2) in enumerate(zip(sumw[0], sumw[1])):
@@ -79,6 +78,8 @@ def install_roofit_helpers():
     # TODO: configurable verbosity
     _ROOT.RooMsgService.instance().setGlobalKillBelow(_ROOT.RooFit.WARNING)
 
+    _ROOT.TH1.AddDirectory(False)
+    
     def _embed_ref(obj, dependents):
         # python reference counting gc will drop rvalue dependents
         # and we don't want to hand ownership to ROOT/RooFit because it's gc is garbage

--- a/rhalphalib/util.py
+++ b/rhalphalib/util.py
@@ -79,7 +79,7 @@ def install_roofit_helpers():
     _ROOT.RooMsgService.instance().setGlobalKillBelow(_ROOT.RooFit.WARNING)
 
     _ROOT.TH1.AddDirectory(False)
-    
+
     def _embed_ref(obj, dependents):
         # python reference counting gc will drop rvalue dependents
         # and we don't want to hand ownership to ROOT/RooFit because it's gc is garbage


### PR DESCRIPTION
I've recently encountered the following warning, when the **first** sample in my model is being rendered for ROOFit:

`TROOT::Append:0: RuntimeWarning: Replacing existing TH1: msd (Potential memory leak).`
(~4000 times)

To get rid of this, i replaced the `SetDirectory(0)` with the 'global' setting `ROOT.TH1.AddDirectory(False)`.

This 'problem' has only appeared recently for me, if i remember correctly. I'm guessing since i switched to CentOS7 due to the new version of combine. 