### PR TITLE
asymmetric lnN bug fix

### DIFF
--- a/rhalphalib/sample.py
+++ b/rhalphalib/sample.py
@@ -404,7 +404,7 @@ class TemplateSample(Sample):
             if down is None:
                 return '%.3f' % up
             else:
-                return '%.3f/%.3f' % (up, down)
+                return '%.3f/%.3f' % (down, up)
 
 
 class ParametericSample(Sample):

--- a/rhalphalib/sample.py
+++ b/rhalphalib/sample.py
@@ -371,7 +371,7 @@ class TemplateSample(Sample):
         if self._paramEffectsUp.get(param, None) is None:
             return '-'
         elif 'shape' in param.combinePrior:
-            return '%.3f' % self._paramEffectScales.get(param, 1)
+            return '%.4f' % self._paramEffectScales.get(param, 1)
         elif isinstance(self.getParamEffect(param, up=True), DependentParameter):
             # about here's where I start to feel painted into a corner
             dep = self.getParamEffect(param, up=True)
@@ -402,9 +402,9 @@ class TemplateSample(Sample):
                 # Here we can safely defer to combine to calculate symmeterized effect
                 down = None
             if down is None:
-                return '%.3f' % up
+                return '%.4f' % up
             else:
-                return '%.3f/%.3f' % (down, up)
+                return '%.4f/%.4f' % (down, up)
 
 
 class ParametericSample(Sample):


### PR DESCRIPTION
Asymmetric log normal systematics in combine are supposed to be written in the datacard as -1sigma/+1sigma effects: https://cms-analysis.github.io/HiggsAnalysis-CombinedLimit/part2/settinguptheanalysis/#a-simple-counting-experiment

Rhalpalib is currently writing it (incorrectly) as +1sigma/-1sigma, which isn't really a big deal until you try to combine with other analyses (that write it the other way).

Also, it may be nice to have one extra decimal place since a lot of standard (theory) uncertainties are now given to the 4th decimal place (e.g. `BR_hbb`).