### PR TITLE
Barlow-Beeston-lite implementation for MC stats uncertainties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__
 *.egg-info
 build
 dist
+.vscode

--- a/rhalphalib/model.py
+++ b/rhalphalib/model.py
@@ -351,7 +351,7 @@ class Channel(object):
     def autoMCStats(self, epsilon=0, threshold=0, include_signal=0, channel_name=None):
         '''
         Barlow-Beeston-lite method i.e. single stats parameter for all processes per bin.
-        Same general algorithm as described in 
+        Same general algorithm as described in
         https://cms-analysis.github.io/HiggsAnalysis-CombinedLimit/part2/bin-wise-stats/
         but *without the analytic minimisation*.
         '''
@@ -369,7 +369,7 @@ class Channel(object):
             for sample in self._samples.values():
                 if not include_signal and sample._sampletype == Sample.SIGNAL:
                     continue
-                
+
                 ntot += sample._nominal[i]
                 etot2 += sample._sumw2[i]
 
@@ -386,7 +386,7 @@ class Channel(object):
                 effect_down = np.ones_like(first_sample._nominal)
 
                 effect_up[i] = (ntot + np.sqrt(etot2)) / ntot
-                effect_down[i] = max((ntot - np.sqrt(etot2))/ ntot, epsilon)
+                effect_down[i] = max((ntot - np.sqrt(etot2)) / ntot, epsilon)
 
                 param = NuisanceParameter(name + '_mcstat_bin%i' % i, combinePrior='shape')
 

--- a/rhalphalib/model.py
+++ b/rhalphalib/model.py
@@ -5,7 +5,7 @@ from itertools import chain
 import os
 import numpy as np
 from .sample import Sample
-from .parameter import Observable, IndependentParameter
+from .parameter import Observable, IndependentParameter, NuisanceParameter
 from .util import _to_numpy, _to_TH1, install_roofit_helpers
 
 
@@ -347,3 +347,46 @@ class Channel(object):
                     effect = sample.combineParamEffect(param)
                     if effect != '-':
                         fout.write(effect + "\n")
+
+    def autoMCStats(self, epsilon=0, threshold=0, include_signal=0, channel_name=None):
+        '''
+        Barlow-Beeston-lite method i.e. single stats parameter for all processes per bin.
+        Same general algorithm as described in 
+        https://cms-analysis.github.io/HiggsAnalysis-CombinedLimit/part2/bin-wise-stats/
+        but *without the analytic minimisation*.
+        '''
+        if not len(self._samples):
+            raise RuntimeError('Channel %r has no samples for which to run autoMCStats' % (self))
+
+        name = self._name if channel_name is None else channel_name
+
+        for i in range(self._samples[0].observable.nbins):
+            ntot, etot2 = 0, 0
+
+            # check if neff = ntot^2 / etot2 > threshold
+            for sample in self._samples:
+                if not include_signal and sample._sampletype == Sample.SIGNAL:
+                    continue
+                
+                ntot += sample._nominal[i]
+                etot2 += sample._sumw2[i]
+
+            if etot2 <= 0.:
+                continue
+
+            neff = ntot ** 2 / etot2
+            if neff <= threshold:
+                for sample in self._samples:
+                    sample_name = None if channel_name is None else channel_name + "_" + sample._name
+                    sample.autoMCStats(epsilon=epsilon, sample_name=sample_name, bini=i)
+            else:
+                effect_up = np.ones_like(self._samples[0]._nominal)
+                effect_down = np.ones_like(self._samples[0]._nominal)
+
+                effect_up[i] = (ntot + np.sqrt(etot2)) / ntot
+                effect_down[i] = max((ntot - np.sqrt(etot2))/ ntot, epsilon)
+
+                param = NuisanceParameter(name + '_mcstat_bin%i' % i, combinePrior='shape')
+
+                for sample in self._samples:
+                    sample.setParamEffect(param, effect_up, effect_down)

--- a/rhalphalib/sample.py
+++ b/rhalphalib/sample.py
@@ -253,10 +253,12 @@ class TemplateSample(Sample):
 
     def autoMCStats(self, lnN=False, epsilon=0, threshold=0, sample_name=None, bini=None):
         '''
-        Set MC statical uncertainties based on self._sumw2
+        Set MC statical uncertainties based on self._sumw2. `sample_name` and `bini` parameters 
+        don't need to modified for typical use cases.
+
         lnN: aggregate differences
         epsilon: 0 -> epsilon, is only one bin is filled lower syst of 0, gives empty norm
-        threshold: if relative uncertainty is < treshold, won't be added (only for lnN = False)
+        threshold: if relative uncertainty is < threshold, won't be added (only for lnN = False)
         sample_name: custom name for e.g. using same parameters in two regions. Uses ``self.name``
             by default (if sample_name=None).
         bini: create parameter for a specific bin. By default creates for all (if bin=None) 

--- a/rhalphalib/sample.py
+++ b/rhalphalib/sample.py
@@ -253,7 +253,7 @@ class TemplateSample(Sample):
 
     def autoMCStats(self, lnN=False, epsilon=0, threshold=0, sample_name=None, bini=None):
         '''
-        Set MC statical uncertainties based on self._sumw2. `sample_name` and `bini` parameters 
+        Set MC statical uncertainties based on self._sumw2. `sample_name` and `bini` parameters
         don't need to modified for typical use cases.
 
         lnN: aggregate differences
@@ -261,7 +261,7 @@ class TemplateSample(Sample):
         threshold: if relative uncertainty is < threshold, won't be added (only for lnN = False)
         sample_name: custom name for e.g. using same parameters in two regions. Uses ``self.name``
             by default (if sample_name=None).
-        bini: create parameter for a specific bin. By default creates for all (if bin=None) 
+        bini: create parameter for a specific bin. By default creates for all (if bin=None)
             (only if lnN = False).
         '''
 
@@ -276,7 +276,7 @@ class TemplateSample(Sample):
                 raise ValueError("No threshold implemented for lnN stat uncertainty")
             if bini is not None:
                 raise ValueError("Bin-specific uncertainty not implemented for lnN stat uncertainty")
-        
+
             _nom_rate = np.sum(self._nominal)
             if _nom_rate < .0001:
                 effect = 1.0
@@ -289,7 +289,7 @@ class TemplateSample(Sample):
             self.setParamEffect(param, effect)
         else:
             if bini is not None:
-                assert bini >= 0 and bini < len(self.observable.nbins), "autoMCStats bini %d out of range for sample %r " % (bini, self)
+                assert bini >= 0 and bini < self.observable.nbins, "autoMCStats bini %d out of range for sample %r " % (bini, self)
 
             for i in range(self.observable.nbins):
                 if bini is not None and bini != i:


### PR DESCRIPTION
- Implements the BB-lite method in the `channel.autoMCStats()` function. 
  - Creates single statistical uncertainty parameter for all samples in the bin
  - Not sure if there's a way to also add in the analytical value for the parameters...
- Minor addition: adds `sample_name`, `threshold`, and `bini` options to the `sample.autoMCStats()` function.

Tested with my analysis templates, results seem reasonable