### PR TITLE
Add signal stats in bblite method

### DIFF
--- a/rhalphalib/model.py
+++ b/rhalphalib/model.py
@@ -354,6 +354,7 @@ class Channel(object):
         Same general algorithm as described in
         https://cms-analysis.github.io/HiggsAnalysis-CombinedLimit/part2/bin-wise-stats/
         but *without the analytic minimisation*.
+        `include_signal` only refers to whether signal stats are included in the *decision* to use bb-lite or not.
         '''
         if not len(self._samples):
             raise RuntimeError('Channel %r has no samples for which to run autoMCStats' % (self))

--- a/rhalphalib/model.py
+++ b/rhalphalib/model.py
@@ -383,7 +383,7 @@ class Channel(object):
                 # this means there is signal but no background, so create stats unc. for signal only
                 for sample in self._samples.values():
                     if sample._sampletype == Sample.SIGNAL:
-                        sample_name = None if channel_name is None else channel_name + "_" + sample._name
+                        sample_name = None if channel_name is None else channel_name + "_" + sample._name[sample._name.find('_') + 1:]
                         sample.autoMCStats(epsilon=epsilon, sample_name=sample_name, bini=i)
 
                 continue
@@ -391,7 +391,7 @@ class Channel(object):
             neff_bb = ntot_bb ** 2 / etot2_bb
             if neff_bb <= threshold:
                 for sample in self._samples.values():
-                    sample_name = None if channel_name is None else channel_name + "_" + sample._name
+                    sample_name = None if channel_name is None else channel_name + "_" + sample._name[sample._name.find('_') + 1:]
                     sample.autoMCStats(epsilon=epsilon, sample_name=sample_name, bini=i)
             else:
                 effect_up = np.ones_like(first_sample._nominal)


### PR DESCRIPTION
Fixes a bug in the Barlow-Beeston-lite method (#26) in which the signal stats weren't being included in the bin MC stats uncertainty.