### PR TITLE
Modifications to include management of statistical uncertainties in TransferFactorSample 

### DIFF
--- a/rhalphalib/sample.py
+++ b/rhalphalib/sample.py
@@ -679,7 +679,6 @@ class TransferFactorSample(ParametericSample):
                         continue
                     effect_up[i] = 1.0 + min(1.0, stat_unc[i])
                     effect_down[i] = max(epsilon, 1.0 - min(1.0, stat_unc[i]))
-                    print("TF",samplename, i, stat_unc[i], name + '_mcstat_bin%i' % i)
                     param = NuisanceParameter(name + '_mcstat_bin%i' % i, combinePrior='shape')
                     MCStat.setParamEffect(param, effect_up, effect_down)
                 params = transferfactor * MCStat.getExpectation() * dependentsample.getExpectation()

--- a/rhalphalib/sample.py
+++ b/rhalphalib/sample.py
@@ -634,7 +634,18 @@ class ParametericSample(Sample):
 
 
 class TransferFactorSample(ParametericSample):
-    def __init__(self, name, sampletype, transferfactor, dependentsample, observable=None, min_val=None):
+    def __init__(self, 
+                 samplename, 
+                 sampletype, 
+                 transferfactor, 
+                 dependentsample, 
+                 nominal_values=None, 
+                 stat_unc=None, 
+                 observable=None, 
+                 min_val=None, 
+                 epsilon=1e-5, 
+                 effect_threshold=0.01, 
+                 channel_name=None):
         """
         Create a sample that depends on another Sample by some transfer factor.
         The transfor factor can be a constant, an array of parameters of same length
@@ -657,15 +668,33 @@ class TransferFactorSample(ParametericSample):
                     params[idx] = p.max(min_val)
         elif len(transferfactor.shape) <= 1:
             observable = dependentsample.observable
-            params = transferfactor * dependentsample.getExpectation()
+            if stat_unc is not None:
+                name = samplename if channel_name is None else channel_name
+                MCStatTemplate = (np.ones_like(stat_unc), observable._binning, observable._name)
+                MCStat = TemplateSample(name+'_mcstat', Sample.BACKGROUND, MCStatTemplate)
+                for i in range(MCStat.observable.nbins):
+                    effect_up = np.ones_like(MCStat._nominal)
+                    effect_down = np.ones_like(MCStat._nominal)
+                    if stat_unc[i] < effect_threshold:
+                        continue
+                    effect_up[i] = 1.0 + min(1.0, stat_unc[i])
+                    effect_down[i] = max(epsilon, 1.0 - min(1.0, stat_unc[i]))
+                    print("TF",samplename, i, stat_unc[i], name + '_mcstat_bin%i' % i)
+                    param = NuisanceParameter(name + '_mcstat_bin%i' % i, combinePrior='shape')
+                    MCStat.setParamEffect(param, effect_up, effect_down)
+                params = transferfactor * MCStat.getExpectation() * dependentsample.getExpectation()
+            else:
+                params = transferfactor * dependentsample.getExpectation()
             if min_val is not None:
                 for i, p in enumerate(params):
                     params[i] = p.max(min_val)
         else:
             raise ValueError("Transfer factor has invalid dimension")
-        super(TransferFactorSample, self).__init__(name, sampletype, observable, params)
+        super(TransferFactorSample, self).__init__(samplename, sampletype, observable, params)
         self._transferfactor = transferfactor
         self._dependentsample = dependentsample
+        self._stat_unc = stat_unc
+        self._nominal_values = nominal_values
 
     @property
     def transferfactor(self):
@@ -674,3 +703,11 @@ class TransferFactorSample(ParametericSample):
     @property
     def dependentsample(self):
         return self._dependentsample
+
+    @property
+    def stat_unc(self):
+        return self._stat_unc
+
+    @property
+    def nominal_values(self):
+        return self._nominal_values


### PR DESCRIPTION
This PR includes the capability to add statistical uncertainties in TransferFactorSample. This is essential when defining transfer factors as ratios of MCs. In those case, the statistical uncertainty can be computed via the propagation of error using the sumw2 of the numerator and denominator and it needs to be added. At the same time, it also needs to be included in the computation of the bin-by-bin BB-lite uncertainty in each channel, as suggested by J. Conway (https://indico.cern.ch/event/107747/contributions/32677/). This approach has been tested in the context of the dark Higgs boson search (SUS-23-013).

Independently from the source, this PR allows TransferFactorSample to take an array that represents the statistical uncertainty in input:

https://github.com/mcremone/rhalphalib/blob/master/rhalphalib/sample.py#L643

Which is then incorporated:

https://github.com/mcremone/rhalphalib/blob/master/rhalphalib/sample.py#L671-L684

The capability to define "nominal values" for the TransferFactorSample is also implemented:

https://github.com/mcremone/rhalphalib/blob/master/rhalphalib/sample.py#L642

This is needed to then add the TransferFactorSample statistical uncertainty to the BB-lite parameters. This is achieved here:

https://github.com/mcremone/rhalphalib/blob/master/rhalphalib/model.py#L374-L397

Other modifications included in this PR are to enable the usage of DependentParameter in the measurement of double-b tagging scale factors performed in the context of the dark Higgs analysis.