### PR TITLE
feat: add eval option to sample.getExpectation() showing param modified yields

### DIFF
--- a/rhalphalib/model.py
+++ b/rhalphalib/model.py
@@ -117,7 +117,7 @@ class Model(object):
         self.renderRoofit(workspace)
         workspace.writeToFile(os.path.join(outputPath, "%s.root" % self.name))
         _seen = set()
-        _duplicated = [x for x in [_p.name for _p in self.parameters] if x in _seen or _seen.add(x)]  
+        _duplicated = [x for x in [_p.name for _p in self.parameters] if x in _seen or _seen.add(x)]
         if len(_duplicated) > 0:
             logging.warning(f"Duplicate instances of parameters with names: {_duplicated} have been found. This is likely not a desired behaviour.")
             for pname in _duplicated:

--- a/rhalphalib/model.py
+++ b/rhalphalib/model.py
@@ -2,6 +2,7 @@ from collections import OrderedDict
 import datetime
 from functools import reduce
 from itertools import chain
+import logging
 import os
 import numpy as np
 from .sample import Sample
@@ -115,6 +116,12 @@ class Model(object):
         workspace = ROOT.RooWorkspace(self.name)
         self.renderRoofit(workspace)
         workspace.writeToFile(os.path.join(outputPath, "%s.root" % self.name))
+        _seen = set()
+        _duplicated = [x for x in [_p.name for _p in self.parameters] if x in _seen or _seen.add(x)]  
+        if len(_duplicated) > 0:
+            logging.warning(f"Duplicate instances of parameters with names: {_duplicated} have been found. This is likely not a desired behaviour.")
+            for pname in _duplicated:
+                logging.warning(f"'{pname}': {[_p for _p in self.parameters if _p.name == pname]}")
         for channel in self:
             channel.renderCard(os.path.join(outputPath, "%s.txt" % channel.name), self.name)
         with open(os.path.join(outputPath, "build.sh"), "w") as fout:

--- a/rhalphalib/parameter.py
+++ b/rhalphalib/parameter.py
@@ -205,7 +205,7 @@ class DependentParameter(Parameter):
 
     @property
     def value(self):
-        return eval(self.formula().format(**{p.name : p.value for p in self.getDependents(deep=True)}))
+        return eval(self.formula().format(**{p.name: p.value for p in self.getDependents(deep=True)}))
 
     @Parameter.intermediate.setter
     def intermediate(self, val):

--- a/rhalphalib/parameter.py
+++ b/rhalphalib/parameter.py
@@ -205,8 +205,7 @@ class DependentParameter(Parameter):
 
     @property
     def value(self):
-        # TODO: value from rendering formula and eval() or numexpr or TFormula or ...
-        raise NotImplementedError
+        return eval(self.formula().format(**{p.name : p.value for p in self.getDependents(deep=True)}))
 
     @Parameter.intermediate.setter
     def intermediate(self, val):

--- a/rhalphalib/parameter.py
+++ b/rhalphalib/parameter.py
@@ -205,7 +205,7 @@ class DependentParameter(Parameter):
 
     @property
     def value(self):
-        return eval(self.formula().replace("_smoothstep", "").format(**{p.name: p.value for p in self.getDependents(deep=True)}))
+        return eval(self.formula().format(**{p.name: p.value for p in self.getDependents(deep=True)}))
 
     @Parameter.intermediate.setter
     def intermediate(self, val):
@@ -267,15 +267,16 @@ class SmoothStep(DependentParameter):
             raise ValueError("Expected a Parameter instance, got %r" % param)
         if param.intermediate:
             raise ValueError("SmoothStep can only depend on a non-intermediate parameter")
+        self.original_name = param.name
         super(SmoothStep, self).__init__(param.name + "_smoothstep", "{0}", param)
         self.intermediate = False
 
     @property
     def value(self):
-        return eval(self.formula().replace("_smoothstep", "").format(**{p.name: p.value for p in self.getDependents(deep=True)}))
+        return eval(self.formula().format(**{p.name: p.value for p in self.getDependents(deep=True)}))
 
     def formula(self, rendering=False):
-        return "{" + self.name + "}"
+        return "((((0.1875**x - 0.625)*x*x + 0.9375)*x + 0.5)*(x > -1)*(x < 1) + 1*(x >= 1))".replace("x", "{%s}" % self.original_name)
 
     def renderRoofit(self, workspace):
         import ROOT

--- a/rhalphalib/parameter.py
+++ b/rhalphalib/parameter.py
@@ -205,7 +205,7 @@ class DependentParameter(Parameter):
 
     @property
     def value(self):
-        return eval(self.formula().format(**{p.name: p.value for p in self.getDependents(deep=True)}))
+        return eval(self.formula().replace("_smoothstep", "").format(**{p.name: p.value for p in self.getDependents(deep=True)}))
 
     @Parameter.intermediate.setter
     def intermediate(self, val):
@@ -272,7 +272,7 @@ class SmoothStep(DependentParameter):
 
     @property
     def value(self):
-        raise NotImplementedError
+        return eval(self.formula().replace("_smoothstep", "").format(**{p.name: p.value for p in self.getDependents(deep=True)}))
 
     def formula(self, rendering=False):
         return "{" + self.name + "}"

--- a/rhalphalib/sample.py
+++ b/rhalphalib/sample.py
@@ -310,7 +310,7 @@ class TemplateSample(Sample):
                 param = NuisanceParameter(name + "_mcstat_bin%i" % i, combinePrior="shape")
                 self.setParamEffect(param, effect_up, effect_down)
 
-    def getExpectation(self, nominal=False):
+    def getExpectation(self, nominal=False, eval=False):
         """
         Create an array of per-bin expectations, accounting for all nuisance parameter effects
             nominal: if True, calculate the nominal expectation (i.e. just plain numbers)
@@ -356,8 +356,11 @@ class TemplateSample(Sample):
                     else:
                         raise NotImplementedError("per-bin effects for other nuisance parameter types")
                     out = out * combined_effect
-
-            return out
+            
+            if eval:
+                return np.array([p.value for p in out])
+            else:
+                return out
 
     def renderRoofit(self, workspace):
         """

--- a/rhalphalib/sample.py
+++ b/rhalphalib/sample.py
@@ -358,7 +358,7 @@ class TemplateSample(Sample):
                     else:
                         raise NotImplementedError("per-bin effects for other nuisance parameter types")
                     out = out * combined_effect
-            
+
             if eval:
                 return np.array([p.value for p in out])
             else:

--- a/rhalphalib/sample.py
+++ b/rhalphalib/sample.py
@@ -120,7 +120,10 @@ class TemplateSample(Sample):
             if sumw2:
                 sumw2[sumw2 < 0] = 0.0
         if np.any(sumw < 0):
-            logging.warning(f"Sample '{name}' template contains negative yields. This may cause normalization mismatch issues when building the workspace. Set `log_level` to 'logging.DEBUG' to show the template:")
+            logging.warning(
+                f"Sample '{name}' template contains negative yields. This may cause normalization mismatch issues when building the workspace. "
+                "Set `log_level` to 'logging.DEBUG' to show the template:"
+            )
             logging.debug(f"Sample '{name}' template = {sumw}.")
         observable = Observable(obs_name, binning)
         self._observable = observable

--- a/rhalphalib/sample.py
+++ b/rhalphalib/sample.py
@@ -117,7 +117,7 @@ class TemplateSample(Sample):
             if np.any(sumw < 0):
                 logging.info(f"Negative values found in sample '{name}'. They are being set to 0.")
             sumw[sumw < 0] = 0.0
-            if sumw2:
+            if sumw2 is not None:
                 sumw2[sumw2 < 0] = 0.0
         if np.any(sumw < 0):
             logging.warning(

--- a/rhalphalib/sample.py
+++ b/rhalphalib/sample.py
@@ -2,6 +2,7 @@ from __future__ import division
 import numpy as np
 import numbers
 import warnings
+import logging
 from .parameter import (
     Parameter,
     IndependentParameter,
@@ -97,7 +98,7 @@ class Sample(object):
 
 
 class TemplateSample(Sample):
-    def __init__(self, name, sampletype, template):
+    def __init__(self, name, sampletype, template, force_positive=False):
         """
         name: self-explanatory
         sampletype: Sample.SIGNAL or BACKGROUND or DATA
@@ -112,6 +113,15 @@ class TemplateSample(Sample):
             sumw, binning, obs_name, sumw2 = _to_numpy(template, read_sumw2=True)
         except ValueError:
             sumw, binning, obs_name = _to_numpy(template)
+        if force_positive:
+            if np.any(sumw < 0):
+                logging.info(f"Negative values found in sample '{name}'. They are being set to 0.")
+            sumw[sumw < 0] = 0.0
+            if sumw2:
+                sumw2[sumw2 < 0] = 0.0
+        if np.any(sumw < 0):
+            logging.warning(f"Sample '{name}' template contains negative yields. This may cause normalization mismatch issues when building the workspace. Set `log_level` to 'logging.DEBUG' to show the template:")
+            logging.debug(f"Sample '{name}' template = {sumw}.")
         observable = Observable(obs_name, binning)
         self._observable = observable
         self._nominal = sumw
@@ -171,8 +181,7 @@ class TemplateSample(Sample):
             else:
                 raise ValueError("Template morphing can only be done via a NuisanceParameter or IndependentParameter")
         if param.name in [p.name for p in self.parameters]:
-            raise ValueError("Parameter {} already exists in sample: {}".format(param.name, [p.name for p in self.parameters]))
-
+            raise ValueError(f"Parameter '{param.name}' already exists in sample '{self.name}': {sorted([p.name for p in self.parameters])}")
         if isinstance(effect_up, np.ndarray):
             if len(effect_up) != self.observable.nbins:
                 raise ValueError("effect_up has the wrong number of bins (%d, expected %d)" % (len(effect_up), self.observable.nbins))
@@ -499,8 +508,7 @@ class ParametericSample(Sample):
         if not isinstance(param, NuisanceParameter):
             raise ValueError("Template morphing can only be done via a NuisanceParameter")
         if param.name in [p.name for p in self.parameters]:
-            raise ValueError("Parameter {} already exists in sample: {}".format(param.name, [p.name for p in self.parameters]))
-
+            raise ValueError(f"Parameter '{param.name}' already exists in sample '{self.name}': {sorted([p.name for p in self.parameters])}")
         if isinstance(effect_up, np.ndarray):
             if len(effect_up) != self.observable.nbins:
                 raise ValueError("effect_up has the wrong number of bins (%d, expected %d)" % (len(effect_up), self.observable.nbins))

--- a/rhalphalib/sample.py
+++ b/rhalphalib/sample.py
@@ -328,6 +328,7 @@ class TemplateSample(Sample):
         """
         Create an array of per-bin expectations, accounting for all nuisance parameter effects
             nominal: if True, calculate the nominal expectation (i.e. just plain numbers)
+            eval: if True, calculate the expectation, based on current parameter values
         """
 
         nominalval = self._nominal.copy()

--- a/rhalphalib/sample.py
+++ b/rhalphalib/sample.py
@@ -170,6 +170,8 @@ class TemplateSample(Sample):
                 return
             else:
                 raise ValueError("Template morphing can only be done via a NuisanceParameter or IndependentParameter")
+        if param.name in [p.name for p in self.parameters]:
+            raise ValueError("Parameter {} already exists in sample: {}".format(param.name, [p.name for p in self.parameters]))
 
         if isinstance(effect_up, np.ndarray):
             if len(effect_up) != self.observable.nbins:
@@ -496,6 +498,8 @@ class ParametericSample(Sample):
         """
         if not isinstance(param, NuisanceParameter):
             raise ValueError("Template morphing can only be done via a NuisanceParameter")
+        if param.name in [p.name for p in self.parameters]:
+            raise ValueError("Parameter {} already exists in sample: {}".format(param.name, [p.name for p in self.parameters]))
 
         if isinstance(effect_up, np.ndarray):
             if len(effect_up) != self.observable.nbins:

--- a/rhalphalib/util.py
+++ b/rhalphalib/util.py
@@ -1,7 +1,9 @@
 import numpy as np
+import copy
 
 
 def _to_numpy(hinput, read_sumw2=False):
+    hinput = copy.deepcopy(hinput)
     if isinstance(hinput, tuple) and len(hinput) >= 3:
         if not isinstance(hinput[0], np.ndarray):
             raise ValueError("Expected numpy array for element 0 of tuple {}".format(hinput))


### PR DESCRIPTION
- Add option to call `sample.getExpectation(eval=True)` which return yields similarly to `sample.getExpectation(nominal=True)` but takes into account the current values of the assigned nuisances
- Force a copy when passing templates to `TemplateSample` to prevent user objects being modified
- Add warnings against negative yields in templates and ` force_positive=True` convenience option to set negative values to 0.
- raise errors when trying to add multiple nuisances with the same name to a channel
- emit warnings when rendendering to combine if multiple nuisances with the same name are still present in the model (eg when they were added to different channels)

@nsmith- 