### PR TITLE
feat: allow getExpectation(eval=True) for samples with independent params; allow shapeU

### DIFF
--- a/src/rhalphalib/model.py
+++ b/src/rhalphalib/model.py
@@ -59,6 +59,16 @@ class Model:
     def parameters(self):
         return reduce(set.union, (c.parameters for c in self), set())
 
+    def getParameter(self, name: str) -> Optional[IndependentParameter]:
+        for p in self.parameters:
+            if p.name == name:
+                return p
+        raise KeyError("Parameter %r not found in channel %r" % (name, self))
+
+    def reset(self):
+        for p in self.parameters:
+            p.reset()
+
     def addChannel(self, channel: "Channel"):
         """Add a channel to the model.
 
@@ -282,6 +292,16 @@ class Channel:
     @property
     def parameters(self):
         return reduce(set.union, (s.parameters for s in self), set())
+
+    def getParameter(self, name: str) -> Optional[IndependentParameter]:
+        for p in self.parameters:
+            if p.name == name:
+                return p
+        raise KeyError("Parameter %r not found in channel %r" % (name, self))
+
+    def reset(self):
+        for p in self.parameters:
+            p.reset()
 
     @property
     def observable(self) -> Observable:

--- a/src/rhalphalib/parameter.py
+++ b/src/rhalphalib/parameter.py
@@ -13,6 +13,7 @@ class Parameter:
     def __init__(self, name: str, value):
         self._name = name
         self._value = value
+        self._initial_value = value
         self._hasPrior = False
         self._intermediate = False
 
@@ -35,6 +36,9 @@ class Parameter:
     @property
     def value(self):
         return self._value
+
+    def reset(self):
+        self._value = self._initial_value
 
     @property
     def intermediate(self):
@@ -328,10 +332,11 @@ class SmoothStep(DependentParameter):
 
     @property
     def value(self) -> float:
+        print("getting smoothstep value")
         return eval(self.formula().format(**{p.name: p.value for p in self.getDependents(deep=True)}))
 
     def formula(self, rendering=False):
-        return "((((0.1875**x - 0.625)*x*x + 0.9375)*x + 0.5)*(x > -1)*(x < 1) + 1*(x >= 1))".replace("x", "{%s}" % self.original_name)
+        return "(((0.1875*x*x - 0.625)*x*x + 0.9375)*x + 0.5)*(x > -1)*(x < 1) + 1*(x >= 1)".replace("x", "{%s}" % self.original_name)
 
     def renderRoofit(self, workspace):
         import ROOT

--- a/src/rhalphalib/parameter.py
+++ b/src/rhalphalib/parameter.py
@@ -332,7 +332,6 @@ class SmoothStep(DependentParameter):
 
     @property
     def value(self) -> float:
-        print("getting smoothstep value")
         return eval(self.formula().format(**{p.name: p.value for p in self.getDependents(deep=True)}))
 
     def formula(self, rendering=False):

--- a/src/rhalphalib/sample.py
+++ b/src/rhalphalib/sample.py
@@ -274,6 +274,8 @@ class TemplateSample(Sample):
                     # we might even want some sort of threshold
                     return
                 elif np.all(effect_up == 1.0) and np.all(effect_down == 1.0):
+                    logging.warning(f"effect_down ({param.name}, {self._name}) = 1 and has no effect, skipping")
+                    del self._paramEffectsUp[param]
                     # some sort of threshold might be useful here as well
                     return
             _weighted_effect_magnitude = np.sum(abs(effect_down - 1) * self._nominal) / np.sum(self._nominal)
@@ -460,10 +462,14 @@ class TemplateSample(Sample):
                     continue
                 name = self.name + "_" + param.name + "Up"
                 shape = nominal * effect_up
+                if np.sum(shape) < 0:
+                    raise RuntimeError(f"Sample '{self.name}' has negative shape for parameter '{param.name}-Up' with value {shape}. Can't build workspace.")
                 rooTemplate = ROOT.RooDataHist(name, name, ROOT.RooArgList(rooObservable), _to_TH1(shape, self.observable.binning, self.observable.name))
                 workspace.add(rooTemplate)
                 name = self.name + "_" + param.name + "Down"
                 shape = nominal * self.getParamEffect(param, up=False)
+                if np.sum(shape) < 0:
+                    raise RuntimeError(f"Sample '{self.name}' has negative shape for parameter '{param.name}-Down with value {shape}. Can't build workspace.")
                 rooTemplate = ROOT.RooDataHist(name, name, ROOT.RooArgList(rooObservable), _to_TH1(shape, self.observable.binning, self.observable.name))
                 workspace.add(rooTemplate)
 


### PR DESCRIPTION
This seems to be needed for models with non-trivial nuisances for eval to work. Otherwise the following error gets raised.

```
File ~/cat/rhalphalib/src/rhalphalib/sample.py:396, in TemplateSample.getExpectation(self, nominal, eval)
    394 else:
    395     effect_down = self.getParamEffect(param, up=False)
--> 396     smoothStep = SmoothStep(param_scaled)
    397     if param.combinePrior == "shape":
    398         combined_effect = smoothStep * (1 + (effect_up - 1) * param_scaled) + (1 - smoothStep) * (1 - (effect_down - 1) * param_scaled)

File ~/cat/rhalphalib/src/rhalphalib/parameter.py:321, in SmoothStep.__init__(self, param)
    319     raise ValueError("Expected a Parameter instance, got %r" % param)
    320 if param.intermediate:
--> 321     raise ValueError("SmoothStep can only depend on a non-intermediate parameter")
    322 self.original_name = param.name
    323 super(SmoothStep, self).__init__(param.name + "_smoothstep", "{0}", param)

ValueError: SmoothStep can only depend on a non-intermediate parameter
```

HOWEVER, I am not sure that it doesn't break anything else, because a change for existing workflows was required.

This PR fixes `getExpectation(eval=True)` to work with more complicated sets of nuisances. A cross check comparing values from fitDiagnostics and getExpectation is here:

![image](https://github.com/user-attachments/assets/3a340ad5-f8fa-46b8-801a-bccbfb8ad069)
